### PR TITLE
Add print keyword

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
-          python -m pip install -r requirements.txt
       - name: Test with pytest
         run: |
           python -m pip install pytest

--- a/clvm_tools/cmds.py
+++ b/clvm_tools/cmds.py
@@ -103,6 +103,9 @@ def launch_tool(args, tool_name, default_stage=0):
         "-v", "--verbose", action="store_true",
         help="Display resolve of all reductions, for debugging")
     parser.add_argument(
+        "-p", "--print-all", action="store_true",
+        help="Print diagnostics for all reductions, for debugging")
+    parser.add_argument(
         "-c", "--cost", action="store_true", help="Show cost")
     parser.add_argument(
         "-m", "--max-cost", type=int, help="Maximum cost")

--- a/clvm_tools/curry.py
+++ b/clvm_tools/curry.py
@@ -35,6 +35,7 @@ def curry(program, args):
         CURRY_OBJ_CODE,
         args,
         quote_kw=KEYWORD_TO_ATOM["q"],
+        print_kw=KEYWORD_TO_ATOM["print"],
         operator_lookup=OPERATOR_LOOKUP,
     )
     return r

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "rt") as fh:
     long_description = fh.read()
 
 dependencies = [
-    "clvm==0.5",
+    "clvm==0.5.4",
 ]
 
 setup(

--- a/stages/stage_0.py
+++ b/stages/stage_0.py
@@ -10,12 +10,13 @@ def run_program(
     program,
     args,
     quote_kw=KEYWORD_TO_ATOM["q"],
+    print_kw=KEYWORD_TO_ATOM["print"],
     operator_lookup=OPERATOR_LOOKUP,
     max_cost=None,
     pre_eval_f=None,
 ):
     return default_run_program(
-        program, args, quote_kw, operator_lookup, max_cost, pre_eval_f=pre_eval_f
+        program, args, quote_kw, print_kw, operator_lookup, max_cost, pre_eval_f=pre_eval_f
     )
 
 


### PR DESCRIPTION
We are intentionally not adding an op_print opcode.
The print atom is intended for debugging in a development environment.
print passes through the value of its reduced arguments, so it can be inserted anywhere in the tree.
'brun -p' and 'run -p' will act as if print is applied to all reductions.
The tests for the print keyword work by re-running all tests with the '-p' flag,
and checking that the output is identical.