### PR TITLE
Deserialize api

### DIFF
--- a/clvm_tools/binutils.py
+++ b/clvm_tools/binutils.py
@@ -46,7 +46,7 @@ def assemble_from_ir(ir_sexp):
 def type_for_atom(atom) -> Type:
     if len(atom) > 2:
         try:
-            v = atom.decode("utf8")
+            v = bytes(atom).decode("utf8")
             if all(c in string.printable for c in v):
                 return Type.QUOTES
         except UnicodeDecodeError:

--- a/clvm_tools/cmds.py
+++ b/clvm_tools/cmds.py
@@ -7,10 +7,10 @@ import pathlib
 import sys
 import time
 
-from clvm import to_sexp_f
+from clvm import to_sexp_f, KEYWORD_FROM_ATOM, KEYWORD_TO_ATOM
 from clvm.EvalError import EvalError
 from clvm.serialize import sexp_from_stream, sexp_to_stream
-from clvm import KEYWORD_FROM_ATOM
+from clvm.operators import OP_REWRITE
 
 from ir import reader
 
@@ -18,9 +18,22 @@ from . import binutils
 from .debug import make_trace_pre_eval, trace_to_text, trace_to_table
 
 try:
-    from clvm_rs import serialize_and_run_program, STRICT_MODE
+    from clvm_rs import deserialize_and_run_program, STRICT_MODE
+
 except ImportError:
-    serialize_and_run_program = None
+    try:
+        from clvm_rs import serialize_and_run_program, STRICT_MODE
+
+        def deserialize_and_run_program(
+            program, args, quote_kw, apply_kw, native_opcodes_by_name, max_cost, flags
+        ):
+            return serialize_and_run_program(
+                program, args, quote_kw, apply_kw, max_cost, flags
+            )
+
+    except ImportError:
+        deserialize_and_run_program = None
+
 
 def path_or_code(arg):
     try:
@@ -205,15 +218,38 @@ def launch_tool(args, tool_name, default_stage=0):
     try:
         output = "(didn't finish)"
 
-        use_rust = (tool_name != "run") and not args.table and not args.stage and (args.backend == "rust" or (serialize_and_run_program and args.backend != "python"))
+        use_rust = (
+            (tool_name != "run")
+            and not pre_eval_f
+            and (
+                args.backend == "rust"
+                or (deserialize_and_run_program and args.backend != "python")
+            )
+        )
         if use_rust:
             if input_serialized == None:
                 input_serialized = input_sexp.as_bin()
 
             run_script = run_script.as_bin()
             time_parse_input = time.perf_counter()
-            cost, result = serialize_and_run_program(
-                run_script, input_serialized, 1, 3, args.max_cost, STRICT_MODE if args.strict else 0)
+
+            # build the opcode look-up table
+            # this should eventually be subsumed by "Dialect" api
+
+            native_opcode_names_by_opcode = dict(
+                ("op_%s" % OP_REWRITE.get(k, k), op)
+                for op, k in KEYWORD_FROM_ATOM.items()
+                if k not in "qa."
+            )
+            cost, result = deserialize_and_run_program(
+                run_script,
+                input_serialized,
+                KEYWORD_TO_ATOM["q"][0],
+                KEYWORD_TO_ATOM["a"][0],
+                native_opcode_names_by_opcode,
+                args.max_cost,
+                STRICT_MODE if args.strict else 0,
+            )
             time_done = time.perf_counter()
             result = sexp_from_stream(io.BytesIO(result), to_sexp_f)
         else:

--- a/clvm_tools/curry.py
+++ b/clvm_tools/curry.py
@@ -1,6 +1,3 @@
-from clvm import KEYWORD_TO_ATOM
-from clvm.operators import OPERATOR_LOOKUP
-
 from clvm_tools.binutils import assemble
 
 from stages.stage_0 import run_program

--- a/clvm_tools/debug.py
+++ b/clvm_tools/debug.py
@@ -106,7 +106,7 @@ def build_symbol_dump(constants_lookup, run_program, path):
     compiled_lookup = {}
     for k, v in constants_lookup.items():
         cost, v1 = run_program(v, v.null())
-        compiled_lookup[sha256tree(v1).hex()] = k.decode()
+        compiled_lookup[sha256tree(v1).hex()] = bytes(k).decode()
     output = json.dumps(compiled_lookup)
     with open(path, "w") as f:
         f.write(output)

--- a/clvm_tools/pattern_match.py
+++ b/clvm_tools/pattern_match.py
@@ -7,7 +7,7 @@ def unify_bindings(bindings, new_key, new_value):
     Try to add a new binding to the list, rejecting it if it conflicts
     with an existing binding.
     """
-    new_key = new_key.decode()
+    new_key = bytes(new_key).decode()
     if new_key in bindings:
         if bindings[new_key] != new_value:
             return None

--- a/ir/utils.py
+++ b/ir/utils.py
@@ -73,7 +73,7 @@ def ir_is_atom(ir_sexp):
 
 
 def ir_as_atom(ir_sexp):
-    return ir_sexp.rest().as_atom()
+    return bytes(ir_sexp.rest().as_atom())
 
 
 def ir_first(ir_sexp):
@@ -90,7 +90,7 @@ def ir_symbol(symbol):
 
 def ir_as_symbol(ir_sexp):
     if ir_sexp.listp() and ir_type(ir_sexp) == Type.SYMBOL:
-        return ir_as_sexp(ir_sexp).as_atom().decode("utf8")
+        return bytes(ir_as_sexp(ir_sexp).as_atom()).decode("utf8")
 
 
 def ir_iter(ir_sexp):

--- a/stages/stage_2/operators.py
+++ b/stages/stage_2/operators.py
@@ -19,7 +19,7 @@ from .optimize import make_do_opt
 
 
 def do_read(args):
-    filename = args.first().as_atom().decode()
+    filename = args.first().as_atom()
     s = open(filename).read()
     ir_sexp = args.to(read_ir(s))
     sexp = assemble_from_ir(ir_sexp)
@@ -27,7 +27,7 @@ def do_read(args):
 
 
 def do_write(args):
-    filename = args.first().as_atom().decode()
+    filename = args.first().as_atom()
     data = args.rest().first()
     with open(filename, "w") as f:
         write_ir_to_stream(disassemble_to_ir(data), f)
@@ -37,9 +37,9 @@ def do_write(args):
 def run_program_for_search_paths(search_paths):
 
     def do_full_path_for_name(args):
-        filename = args.first().as_atom().decode()
+        filename = args.first().as_atom()
         for path in search_paths:
-            f_path = pathlib.Path(path) / filename
+            f_path = pathlib.Path(path) / bytes(filename).decode()
             if f_path.is_file():
                 return 1, args.to(str(f_path).encode())
         raise EvalError("can't open %s" % filename, args)


### PR DESCRIPTION
Create new `deserialize_and_run_program` api that doesn't hard-code operator indices. This should get us a little further along in our "renumber opcodes" trello card.