### PR TITLE
Minimal paths

### DIFF
--- a/clvm_tools/NodePath.py
+++ b/clvm_tools/NodePath.py
@@ -71,7 +71,9 @@ class NodePath:
         self._index = index
 
     def as_short_path(self):
-        return self._index
+        index = self._index
+        byte_count = (index.bit_length() + 7) >> 3
+        return index.to_bytes(byte_count, byteorder="big")
 
     def as_long_path(self):
         r = [ARGS_KW]

--- a/tests/stage_2/minimal-paths-1.txt
+++ b/tests/stage_2/minimal-paths-1.txt
@@ -1,0 +1,2 @@
+run '(mod (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11) A7)'
+-65


### PR DESCRIPTION
Don't use paths with leading zeros, like it would with `0084` (it didn't want numbers to "look" negative).