### PR TITLE
Paginate hex files every 80 characters

### DIFF
--- a/clvm_tools/clvmc.py
+++ b/clvm_tools/clvmc.py
@@ -30,7 +30,7 @@ def compile_clvm(input_path, output_path, search_paths=[]):
         hex = result.as_bin().hex()
 
         with open(output_path, "w") as f:
-            f.write(hex)
+            f.write(insert_newlines(hex))
             f.write("\n")
     else:
         log.info("skipping %s, compiled recently" % input_path)
@@ -48,3 +48,9 @@ def find_files(path=""):
                 compile_clvm(full_path, target)
                 r.append(target)
     return r
+
+def insert_newlines(string, every=80):
+    lines = []
+    for i in range(0, len(string), every):
+        lines.append(string[i:i+every])
+    return '\n'.join(lines)


### PR DESCRIPTION
This was brought up during the discussion of what to do when refactoring how CLVM is handled in our repositories.  Open to other lengths of characters, this was just the one brought up I believe.