### PR TITLE
brun cost

### DIFF
--- a/clvm_tools/cmds.py
+++ b/clvm_tools/cmds.py
@@ -170,18 +170,17 @@ def launch_tool(args, tool_name, default_stage=0):
     else:
         run_program = args.stage.run_program
 
-    input_serialized = None
-    input_sexp = None
+    program_serialized = None
+    arg_serialized = None
 
     time_start = time.perf_counter()
     if args.hex:
-        assembled_serialized = bytes.fromhex(args.path_or_code)
+        program_serialized = bytes.fromhex(args.path_or_code)
         if not args.env:
             args.env = "80"
-        env_serialized = bytes.fromhex(args.env)
+        arg_serialized = bytes.fromhex(args.env)
         time_read_hex = time.perf_counter()
 
-        input_serialized = b"\xff" + assembled_serialized + env_serialized
     else:
 
         src_text = args.path_or_code
@@ -190,14 +189,13 @@ def launch_tool(args, tool_name, default_stage=0):
         except SyntaxError as ex:
             print("FAIL: %s" % (ex))
             return -1
-        assembled_sexp = binutils.assemble_from_ir(src_sexp)
+        program_serialized = binutils.assemble_from_ir(src_sexp).as_bin()
         if not args.env:
             args.env = "()"
         env_ir = reader.read_ir(args.env)
-        env = binutils.assemble_from_ir(env_ir)
-        time_assemble = time.perf_counter()
+        arg_serialized = binutils.assemble_from_ir(env_ir).as_bin()
 
-        input_sexp = to_sexp_f((assembled_sexp, env))
+        time_assemble = time.perf_counter()
 
     pre_eval_f = None
     symbol_table = None
@@ -211,7 +209,9 @@ def launch_tool(args, tool_name, default_stage=0):
     elif args.verbose or args.table:
         pre_eval_f = make_trace_pre_eval(log_entries)
 
-    run_script = getattr(args.stage, tool_name)
+    if hasattr(args.stage, tool_name):
+        arg_serialized = b"\xff" + program_serialized + arg_serialized
+        program_serialized = getattr(args.stage, tool_name).as_bin()
 
     cost = 0
     try:
@@ -224,30 +224,27 @@ def launch_tool(args, tool_name, default_stage=0):
                 args.backend == "rust"
                 or (run_chia_program and args.backend != "python")
             )
+            and args.stage == 0
         )
         max_cost = args.max_cost
         if use_rust:
-            if input_serialized is None:
-                input_serialized = input_sexp.as_bin()
-
-            run_script = run_script.as_bin()
             time_parse_input = time.perf_counter()
 
             cost, result = run_chia_program(
-                run_script,
-                input_serialized,
+                program_serialized,
+                arg_serialized,
                 max_cost,
                 MEMPOOL_MODE if (args.mempool or args.strict) else 0,
             )
             time_done = time.perf_counter()
             result = SExp.to(result)
         else:
-            if input_sexp is None:
-                input_sexp = sexp_from_stream(io.BytesIO(input_serialized), to_sexp_f)
+            program = sexp_from_stream(io.BytesIO(program_serialized), to_sexp_f)
+            arg = sexp_from_stream(io.BytesIO(arg_serialized), to_sexp_f)
 
             time_parse_input = time.perf_counter()
             cost, result = run_program(
-                run_script, input_sexp, max_cost=max_cost, pre_eval_f=pre_eval_f, strict=args.mempool | args.strict)
+                program, arg, max_cost=max_cost, pre_eval_f=pre_eval_f, strict=args.mempool | args.strict)
             time_done = time.perf_counter()
         if args.cost:
             print("cost = %d" % cost)

--- a/clvm_tools/cmds.py
+++ b/clvm_tools/cmds.py
@@ -104,22 +104,6 @@ def brun(args=sys.argv):
     return launch_tool(args, "brun")
 
 
-def calculate_cost_offset(run_program, run_script: SExp):
-    """
-    These commands are used by the test suite, and many of them expect certain costs.
-    If boilerplate invocation code changes by a fixed cost, you can tweak this
-    value so you don't have to change all the tests' expected costs.
-
-    Eventually you should re-tare this to zero and alter the tests' costs though.
-
-    This is a hack and need to go away, probably when we do dialects for real,
-    and then the dialect can have a `run_program` API.
-    """
-    null = binutils.assemble("0")
-    cost, _r = run_program(run_script, null.cons(null))
-    return 53 - cost
-
-
 def launch_tool(args, tool_name, default_stage=0):
     sys.setrecursionlimit(20000)
     parser = argparse.ArgumentParser(
@@ -230,7 +214,6 @@ def launch_tool(args, tool_name, default_stage=0):
     run_script = getattr(args.stage, tool_name)
 
     cost = 0
-    cost_offset = calculate_cost_offset(run_program, run_script)
     try:
         output = "(didn't finish)"
 
@@ -242,7 +225,7 @@ def launch_tool(args, tool_name, default_stage=0):
                 or (run_chia_program and args.backend != "python")
             )
         )
-        max_cost = max(0, args.max_cost - cost_offset if args.max_cost != 0 else 0)
+        max_cost = args.max_cost
         if use_rust:
             if input_serialized is None:
                 input_serialized = input_sexp.as_bin()
@@ -267,7 +250,6 @@ def launch_tool(args, tool_name, default_stage=0):
                 run_script, input_sexp, max_cost=max_cost, pre_eval_f=pre_eval_f, strict=args.mempool | args.strict)
             time_done = time.perf_counter()
         if args.cost:
-            cost += cost_offset if cost > 0 else 0
             print("cost = %d" % cost)
         if args.time:
             if args.hex:

--- a/stages/stage_0.py
+++ b/stages/stage_0.py
@@ -4,9 +4,6 @@ from clvm.EvalError import EvalError
 
 from clvm_tools import binutils
 
-brun = run = binutils.assemble("(a 2 3)")
-
-
 def run_program(
     program,
     args,

--- a/stages/stage_1.py
+++ b/stages/stage_1.py
@@ -53,9 +53,6 @@ BINDINGS = {
 }
 
 
-brun = run = binutils.assemble("(a 2 3)")
-
-
 class RunProgram:
     def __init__(self):
         operator_lookup = OperatorDict(OPERATOR_LOOKUP)

--- a/tests/cmd/trace-table.txt
+++ b/tests/cmd/trace-table.txt
@@ -1,29 +1,5 @@
 brun -t '(+ 1 (q . 3))' '2'
 5
-exp: 2
-arg: (a 3)
-env: ((+ 1 (q . 3)) . 2)
-val: 5
-bexp: b'\x02'
-barg: b'\xff\x02\xff\x03\x80'
-benv: b'\xff\xff\x10\xff\x01\xff\xff\x01\x03\x80\x02'
---
-exp: 3
-arg: ()
-env: ((+ 1 (q . 3)) . 2)
-val: 2
-bexp: b'\x03'
-barg: b'\x80'
-benv: b'\xff\xff\x10\xff\x01\xff\xff\x01\x03\x80\x02'
---
-exp: 2
-arg: ()
-env: ((+ 1 (q . 3)) . 2)
-val: (+ 1 (q . 3))
-bexp: b'\x02'
-barg: b'\x80'
-benv: b'\xff\xff\x10\xff\x01\xff\xff\x01\x03\x80\x02'
---
 exp: 16
 arg: (q (q . 3))
 env: 2


### PR DESCRIPTION
This simplifies the `brun` (and to some extent the `run`) tool. Most importantly, it makes `brun` report accurate cost by removing the cost offset hack and the launcher program, and runs the passed in program directly.