### PR TITLE
when decompiling, don't consider new-line or double-quote printable

### DIFF
--- a/clvm_tools/binutils.py
+++ b/clvm_tools/binutils.py
@@ -1,4 +1,3 @@
-import string
 from typing import Dict
 
 from clvm import KEYWORD_FROM_ATOM, KEYWORD_TO_ATOM
@@ -45,11 +44,15 @@ def assemble_from_ir(ir_sexp):
     return sexp_1.cons(sexp_2)
 
 
+printable_chars = ("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "!#$%&'()*+,-./:;<=>?@[\]^_`{|}~ ")
+
+
 def type_for_atom(atom) -> Type:
     if len(atom) > 2:
         try:
             v = bytes(atom).decode("utf8")
-            if all(c in string.printable for c in v):
+            if all(c in printable_chars for c in v):
                 return Type.QUOTES
         except UnicodeDecodeError:
             pass


### PR DESCRIPTION
Including double-quotes in quoted strings is problematic for obvious reasons. Including new-lines in quotes strings is technically not a problem, the parser will treat those as `0x0a` bytes, but it's not very user-friendly.

The full list of characters in `strings.printable` is:

```
0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
```

also including

* ASCII 9 (Tab)
* ASCII 10 (Line feed)
* ASCII 11 (Vertical tab)
* ASCII 12 (Form feed)
* ASCII 13 (Carriage return)

This patch removes all control characters and double-quote from the list of "printable" characters (for the purposes of deciding how to render an atom in the de-compiled output).