### PR TITLE
Bump version to clvm_tools_rs 0.1.36

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "rt") as fh:
 
 dependencies = [
     "clvm>=0.9.2",
-    "clvm_tools_rs>=0.1.25"
+    "clvm_tools_rs>=0.1.36"
 ]
 
 dev_dependencies = [


### PR DESCRIPTION
Import new version of clvm_tools_rs which has the new bls and secp256 operators.