### PR TITLE
Add python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
+          python -m pip install .[dev]
       - name: Test with pytest
         run: |
-          python -m pip install pytest
-          py.test tests
+          pytest tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     name: Python ${{ matrix.os }} ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v3

--- a/clvm_tools/__init__.py
+++ b/clvm_tools/__init__.py
@@ -1,7 +1,7 @@
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib_metadata
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = importlib_metadata.version(__name__)
+except importlib_metadata.PackageNotFoundError:
     # package is not installed
     __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.md", "rt") as fh:
 dependencies = [
     "clvm>=0.9.2",
     "clvm_tools_rs>=0.1.37",
+    "importlib_metadata",
     "setuptools",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ with open("README.md", "rt") as fh:
 dependencies = [
     "clvm>=0.9.2",
     "clvm_tools_rs>=0.1.37",
-    "importlib_metadata~=6.11.0",
     "setuptools",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "rt") as fh:
 
 dependencies = [
     "clvm @ git+https://github.com/chia-network/clvm@replace_pkg_resources",
-    "clvm_tools_rs>=0.1.37"
+    "clvm_tools_rs @ git+https://github.com/chia-network/clvm_tools_rs@main"
 ]
 
 dev_dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "rt") as fh:
 
 dependencies = [
     "clvm @ git+https://github.com/chia-network/clvm@replace_pkg_resources",
-    "clvm_tools_rs @ git+https://github.com/chia-network/clvm_tools_rs@main"
+    "clvm_tools_rs @ git+https://github.com/chia-network/clvm_tools_rs@base"
 ]
 
 dev_dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,10 @@ with open("README.md", "rt") as fh:
     long_description = fh.read()
 
 dependencies = [
-    "clvm @ git+https://github.com/chia-network/clvm@replace_pkg_resources",
-    "clvm_tools_rs @ git+https://github.com/chia-network/clvm_tools_rs@base"
+    "clvm>=0.9.2",
+    "clvm_tools_rs>=0.1.37",
+    "importlib_metadata~=6.11.0",
+    "setuptools",
 ]
 
 dev_dependencies = [
@@ -16,7 +18,13 @@ dev_dependencies = [
 
 setup(
     name="clvm_tools",
-    packages=["ir", "clvm_tools", "clvm_tools.setuptools", "stages", "stages.stage_2",],
+    packages=[
+        "ir",
+        "clvm_tools",
+        "clvm_tools.setuptools",
+        "stages",
+        "stages.stage_2",
+    ],
     author="Chia Network, Inc.",
     entry_points={
         "console_scripts": [
@@ -45,7 +53,9 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Security :: Cryptography",
     ],
-    extras_require=dict(dev=dev_dependencies,),
+    extras_require=dict(
+        dev=dev_dependencies,
+    ),
     project_urls={
         "Bug Reports": "https://github.com/Chia-Network/clvm_tools",
         "Source": "https://github.com/Chia-Network/clvm_tools",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "rt") as fh:
     long_description = fh.read()
 
 dependencies = [
-    "clvm>=0.9.2",
+    "clvm @ git+https://github.com/chia-network/clvm@replace_pkg_resources",
     "clvm_tools_rs>=0.1.37"
 ]
 

--- a/tests/cmds_test.py
+++ b/tests/cmds_test.py
@@ -1,9 +1,10 @@
-import importlib
 import io
 import os
 import shlex
 import sys
 import unittest
+
+import importlib_metadata
 
 # If the REPAIR environment variable is set, any tests failing due to
 # wrong output will be corrected. Be sure to do a "git diff" to validate that
@@ -56,7 +57,7 @@ class TestCmds(unittest.TestCase):
         sys.stderr = stderr_buffer
 
         args = shlex.split(cmd_line)
-        [entry_point] = importlib.metadata.entry_points(group="console_scripts", name=args[0])
+        [entry_point] = importlib_metadata.entry_points(group="console_scripts", name=args[0])
         v = entry_point.load()(args)
 
         sys.stdout = old_stdout

--- a/tests/cmds_test.py
+++ b/tests/cmds_test.py
@@ -1,10 +1,9 @@
+import importlib
 import io
 import os
-import pkg_resources
 import shlex
 import sys
 import unittest
-
 
 # If the REPAIR environment variable is set, any tests failing due to
 # wrong output will be corrected. Be sure to do a "git diff" to validate that
@@ -57,9 +56,8 @@ class TestCmds(unittest.TestCase):
         sys.stderr = stderr_buffer
 
         args = shlex.split(cmd_line)
-        v = pkg_resources.load_entry_point("clvm_tools", "console_scripts", args[0])(
-            args
-        )
+        [entry_point] = importlib.metadata.entry_points(group="console_scripts", name=args[0])
+        v = entry_point.load()(args)
 
         sys.stdout = old_stdout
         sys.stderr = old_stderr


### PR DESCRIPTION
Added `setuptools` for `distutils` - should be removed eventually
Changed version stuff to use `importlib_metadata`

- [x] need chia_rs 3.12 wheel
- [x] needs new clvm wheel published that uses chia_rs (that pr is merged)
