### PR TITLE
Remove support for python3.9 and switch core ops to 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,14 +3,14 @@ name: Tests
 on:
   push:
     branches:
-      - 'long_lived/**'
+      - "long_lived/**"
       - main
-      - 'release/**'
+      - "release/**"
     tags:
-        - '**'
+      - "**"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   build:
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: ["3.10", "3.11", "3.12"]
     name: Python ${{ matrix.os }} ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,14 +5,14 @@ name: Publish Python distributions to PyPI
 on:
   push:
     branches:
-      - 'long_lived/**'
+      - "long_lived/**"
       - main
-      - 'release/**'
+      - "release/**"
     tags:
-        - '**'
+      - "**"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 permissions:
   contents: read
@@ -24,35 +24,35 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - run: |
-        git fetch origin +refs/tags/*:refs/tags/*
+      - run: |
+          git fetch origin +refs/tags/*:refs/tags/*
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-    - name: Build a binary wheel and a source tarball 
-      run: |
-        python -m venv venv
-        source venv/bin/activate
-        python -m pip install --upgrade pip
-        pip install build
-        python -m build --outdir dist .
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build --outdir dist .
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist
-        path: ./dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist
 
-    - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        packages-dir: dist/
-        skip-existing: true
+      - name: Publish distribution to PyPI
+        if: startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,307 @@
-__pycache__
+# The last section of this file is generated.  Please locate custom edits
+# outside of that area and only update that section using the original site
+# that generated it.  Links provided below.
+
+
+# C extensions
+**/*.o
+**/*.DS_Store
+
+# Database
+nohup.out
+mongod.log*
+fndb_test*
+*.db
+*.db-journal
+
+# Logs
+*.log
+*.out
+
+# Keys and plot files
+config/keys.yaml
+config/plots.yaml
+
+# Bundled code
+clvm_tools.tar.gz.tar.gz
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+build_scripts/build
+
+# Installer logs
+**/*.egg-info
+
+# PoSpace plots
+**/*.dat
+**/*.dat.tmp
+*.mo
+*.pot
+
+# pyenv
+.python-version
+.penv*/
+.venv*/
+venv*/
+venv*
+activate
+
+# Editors
+.vscode
+.idea
+.vs
+
+# Packaging
+clvm_tools.tar.gz
+
+# Timelord utilities
+vdf_bench
+
+# Node modules
+**/node_modules
+
+# Offer Files
+*.offer
+
+# Backup Files
+*.backup
+
+# Attest Files
+*.attest
+
+# Compiled CLVM
+main.sym
+*.recompiled
+
+# Profiling
+*.prof
+*.pstats
+
+# Dev config react
+# React built app
+build_scripts/dist
+build_scripts/*.Dmg
+build_scripts\win_build
+build_scripts/win_build
+win_code_sign_cert.p12
+build_scripts/**/.nx/cache
+
+# clvm_tools wheel build folder
+build/
+
+# Temporal `n` (node version manager) directory
+.n/
+
+# pytest-monitor
+# https://pytest-monitor.readthedocs.io/en/latest/operating.html?highlight=.pymon#storage
+.pymon
+
+# cache for tooling such as tools/manage_clvm.py
+.chia_cache/
+
+#       =====                       =====
+#     DO NOT EDIT BELOW - GENERATED
+#       =====                       =====
+#
+# If you want to modify below please use the site linked below to generate an update
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,git,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,git,vim
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+mypy.ini
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/python,git,vim
+
+# Ignore the binaries that are pulled for the installer
+/bladebit/
+/madmax/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
-
-[tool.setuptools_scm]
-fallback_version = "unknown"
-local_scheme = "no-local-version"
+requires = ["setuptools>=80", "wheel", "setuptools_scm[toml]>=8"]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This PR drops support for Python3.9 which is EOL at the end of October and switches core operations from 3.10 (now the lowest supported version) to 3.12.  It also adds a `.gitignore` largely copy/pasted from chia-blockchain.

(My editor also linted the yaml)