### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that narrows the default GITHUB_TOKEN to read-only repository contents; no application or signing logic changes.
> 
> **Overview**
> Adds an explicit **`permissions: contents: read`** block to the **Check commit signing** GitHub Actions workflow, aligning it with other workflows (e.g. dependency review) that declare least-privilege access instead of relying on the default token scope.
> 
> No changes to triggers, jobs, or steps—only workflow-level permission hardening for supply-chain / security hygiene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9bee040e2322ad50f9e6be4ba490e180a8b179f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->